### PR TITLE
Fix log fixture docstring

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -37,7 +37,7 @@ def product_list(base_url):
 
 @pytest.fixture(autouse=True)
 def log_request_response():
-    """Auto-log every requests request + response status."""
+    """Auto-log every HTTP request and response status."""
     old_get = requests.get
     old_post = requests.post
 


### PR DESCRIPTION
## Summary
- clarify wording about logging HTTP requests in `log_request_response`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684177a8d990832ab27a73dbfb816545